### PR TITLE
Large images

### DIFF
--- a/src/main/java/util/FindConnectedRegions.java
+++ b/src/main/java/util/FindConnectedRegions.java
@@ -748,15 +748,31 @@ public class FindConnectedRegions {
 
 	/** Byte array container which can exceed 2G elements. */
 	public class PointState {
-		private byte[] state;
-		public PointState(long size) {
-			state = new byte[(int) size];
+		private static final int CHUNK_SIZE = 1024 * 1024 * 1024; // 1 GB
+		private final byte[][] state;
+
+		public PointState(final long size) {
+			final int numArrays = (int) (size / CHUNK_SIZE) + 1;
+			state = new byte[numArrays][];
+			int i = 0;
+			long remain = size;
+			while (remain > 0) {
+				int len = remain > CHUNK_SIZE ? CHUNK_SIZE : (int) remain;
+				state[i++] = new byte[len];
+				remain -= len;
+			}
 		}
-		public void set(long i, byte value) {
-			state[(int) i] = value;
+
+		public void set(final long index, final byte value) {
+			final int a = (int) (index / CHUNK_SIZE);
+			final int i = (int) (index % CHUNK_SIZE);
+			state[a][i] = value;
 		}
-		public byte get(final long i) {
-			return state[(int) i];
+
+		public byte get(final long index) {
+			final int a = (int) (index / CHUNK_SIZE);
+			final int i = (int) (index % CHUNK_SIZE);
+			return state[a][i];
 		}
 	}
 


### PR DESCRIPTION
This breaks the 2^31-1 width_height_slices limitation, which results in a `NegativeArraySizeException` as [reported on #fiji-devel](http://code.imagej.net/chatlogs/fiji-devel?search=&start-date=2014-04-22&end-date=2014-04-22&format=html&columns=78&times=sparse&submit=search):

```
java.lang.NegativeArraySizeException
        at util.FindConnectedRegions.run(FindConnectedRegions.java:347)
        at util.Find_Connected_Regions.run(Find_Connected_Regions.java:105)
        at ij.IJ.runUserPlugIn(IJ.java:199)
        at ij.IJ.runPlugIn(IJ.java:163)
        at ij.Executer.runCommand(Executer.java:131)
        at ij.Executer.run(Executer.java:64)
        at java.lang.Thread.run(Thread.java:662)
```

@mhl, @dscho: See anything blatantly wrong? Main relevant commits are e62eec4 and 0ac8da3. Unit tests still pass. But I don't have enough RAM on my box to test it with a really large stack.
