### PR TITLE
Make openAffineTransform(path) public

### DIFF
--- a/src/main/java/math3d/TransformIO.java
+++ b/src/main/java/math3d/TransformIO.java
@@ -46,7 +46,7 @@ public class TransformIO {
 	String getFields() {return nh==null?null:nh.getFieldStrings();}	
 	String getHeader() {return nh==null?null:nh.toString();}	
 
-	float[] openAffineTransform(String path) {
+	public float[] openAffineTransform(String path) {
 		nh=new NrrdHeader();
 		float[] mat = new float[matSize];
 		try {


### PR DESCRIPTION
This allows usage of both openAffineTransform(path) and saveAffineTransform(path, mat) from scripts.