### PR TITLE
Name Landmarks: rename button Export to CMTK

### DIFF
--- a/src/main/java/landmarks/NamePoints.java
+++ b/src/main/java/landmarks/NamePoints.java
@@ -268,7 +268,7 @@ class PointsDialog extends Dialog implements ActionListener, WindowListener {
 			saveButton.addActionListener(this);
 			loadButton = new Button("Load");
 			loadButton.addActionListener(this);
-			igsSaveButton = new Button("Export to IGS");
+			igsSaveButton = new Button("Export to CMTK");
 			igsSaveButton.addActionListener(this);
 			resetButton = new Button("Reset All");
 			resetButton.addActionListener(this);


### PR DESCRIPTION
* IGS was the old name of the CMTK registration suite but has been defunct for many years
* rename to make it easier for people to appreciate the connection to CMTK